### PR TITLE
Update to master 1.12.1, keep flash fix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Major changes in 1.12.1 are:
+* Assorted bugfixes
+* Translations update
+
 Major changes in 1.12.0 are:
 * Connect to server dialog: add support for AFP
 * Retrieve strings directly from gschema (requires intltool 0.50.1)

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ dnl Interface break is not allowed.
 m4_define(caja_extension_current,  5)
 m4_define(caja_extension_revision, 0)
 
-AC_INIT([caja], [1.12.0], [http://www.mate-desktop.org])
+AC_INIT([caja], [1.12.1], [http://www.mate-desktop.org])
 
 # GLib min/max required versions
 AC_DEFINE([GLIB_VERSION_MAX_ALLOWED], [GLIB_VERSION_2_36],

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -5825,6 +5825,7 @@ select_image_button_callback (GtkWidget *widget,
 						      GTK_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
 						      GTK_STOCK_OPEN, GTK_RESPONSE_OK,
 						      NULL);
+		gtk_file_chooser_add_shortcut_folder (GTK_FILE_CHOOSER (dialog), "/usr/share/icons", NULL);
 		gtk_file_chooser_add_shortcut_folder (GTK_FILE_CHOOSER (dialog), "/usr/share/pixmaps", NULL);
 		gtk_window_set_destroy_with_parent (GTK_WINDOW (dialog), TRUE);
 


### PR DESCRIPTION
Merging mate-desktop/master commits from after this branch was forked and a PR made for the desktop flash fix #4.

This branch to be kept up with 1.12.1 and to be the source of subsequent branches until either the flashfix4 PR is merged or another (maybe better?)  fix for the desktop flashes is made in mate-desktop/caja. New branch so existing PR is not disturbed.