### PR TITLE
GTK3: Fix caja information panel

### DIFF
--- a/src/caja-information-panel.c
+++ b/src/caja-information-panel.c
@@ -1045,6 +1045,11 @@ caja_information_panel_update_buttons (CajaInformationPanel *information_panel)
 static void
 caja_information_panel_update_appearance (CajaInformationPanel *information_panel)
 {
+
+#if GTK_CHECK_VERSION(3,0,0)
+    gtk_style_context_add_class (gtk_widget_get_style_context (GTK_WIDGET (information_panel)),
+                                 GTK_STYLE_CLASS_VIEW);
+#else
     EelBackground *background;
     char *background_color;
     char *background_image;
@@ -1102,6 +1107,7 @@ caja_information_panel_update_appearance (CajaInformationPanel *information_pane
     g_signal_handlers_unblock_by_func (background,
                                        G_CALLBACK (background_settings_changed_callback),
                                        information_panel);
+#endif
 }
 
 static void


### PR DESCRIPTION
The Caja information panel (information option in sidebar) was never fully ported to GTK3, probably still isn't. Set the .view style class on it, and exclude the rest of caja_information_panel_update_appearance as that code segfaults (at least with GTK 3.21) on dragging a background to the info panel.

We now have a demo for background dragging in GTK3: A background can be dragged to the information sidebar and will be displayed. Won't be saved and won't appear in other Cajs navigation windows, something in the code that segfaulted no doubt needs to be fixed for that but that's for later. At least this widget finally works. It will follow any theme I have and no longer fails to update to  BlackMATE or my own theme.