### PR TITLE
Avoid deprecated gdk_cairo_create

### DIFF
--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -80,7 +80,11 @@ struct EelBackgroundDetails
     MateBGCrossfade *fade;
     int bg_entire_width;
     int bg_entire_height;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GdkRGBA default_color;
+#else
     GdkColor default_color;
+#endif
 
     gboolean use_base;
 
@@ -166,7 +170,11 @@ eel_background_unrealize (EelBackground *self)
 
 static void
 make_color_inactive (EelBackground *self,
+#if GTK_CHECK_VERSION (3, 0, 0)
+		     GdkRGBA      *color)
+#else
 		     GdkColor      *color)
+#endif
 {
     double intensity, saturation;
     gushort t;
@@ -201,7 +209,11 @@ gchar *
 eel_bg_get_desktop_color (EelBackground *self)
 {
     MateBGColorType type;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GdkRGBA    primary, secondary;
+#else
     GdkColor   primary, secondary;
+#endif
     char      *start_color, *end_color, *color_spec;
     gboolean   use_gradient = TRUE;
     gboolean   is_horizontal = FALSE;
@@ -221,11 +233,19 @@ eel_bg_get_desktop_color (EelBackground *self)
         use_gradient = FALSE;
     }
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    start_color = eel_gdk_rgb_to_color_spec (eel_gdk_rgba_to_rgb (&primary));
+
+    if (use_gradient)
+    {
+        end_color  = eel_gdk_rgb_to_color_spec (eel_gdk_rgba_to_rgb (&secondary));
+#else
     start_color = eel_gdk_rgb_to_color_spec (eel_gdk_color_to_rgb (&primary));
 
     if (use_gradient)
     {
         end_color  = eel_gdk_rgb_to_color_spec (eel_gdk_color_to_rgb (&secondary));
+#endif
         color_spec = eel_gradient_new (start_color, end_color, is_horizontal);
         g_free (end_color);
     }
@@ -241,7 +261,11 @@ eel_bg_get_desktop_color (EelBackground *self)
 static void
 set_image_properties (EelBackground *self)
 {
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GdkRGBA c;
+#else
     GdkColor c;
+#endif
 
     if (self->details->is_desktop && !self->details->color)
         self->details->color = eel_bg_get_desktop_color (self);
@@ -254,22 +278,39 @@ set_image_properties (EelBackground *self)
     }
     else if (!eel_gradient_is_gradient (self->details->color))
     {
+#if GTK_CHECK_VERSION (3, 0, 0)
+        eel_gdk_rgba_parse_with_white_default (&c, self->details->color);
+#else
         eel_gdk_color_parse_with_white_default (self->details->color, &c);
+#endif
         make_color_inactive (self, &c);
         mate_bg_set_color (self->details->bg, MATE_BG_COLOR_SOLID, &c, NULL);
     }
     else
     {
+#if GTK_CHECK_VERSION (3, 0, 0)
+        GdkRGBA c1, c2;
+#else
         GdkColor c1, c2;
+#endif
         char *spec;
 
         spec = eel_gradient_get_start_color_spec (self->details->color);
+#if GTK_CHECK_VERSION (3, 0, 0)
+        eel_gdk_rgba_parse_with_white_default (&c1, spec);
+        make_color_inactive (self, &c1);
+        g_free (spec);
+
+        spec = eel_gradient_get_end_color_spec (self->details->color);
+        eel_gdk_rgba_parse_with_white_default (&c2, spec);
+#else
         eel_gdk_color_parse_with_white_default (spec, &c1);
         make_color_inactive (self, &c1);
         g_free (spec);
 
         spec = eel_gradient_get_end_color_spec (self->details->color);
         eel_gdk_color_parse_with_white_default (spec, &c2);
+#endif
         make_color_inactive (self, &c2);
         g_free (spec);
 
@@ -333,9 +374,24 @@ drawable_get_adjusted_size (EelBackground *self,
 static gboolean
 eel_background_ensure_realized (EelBackground *self)
 {
-    GtkStyle *style;
     int width, height;
     GdkWindow *window;
+#if GTK_CHECK_VERSION (3, 0, 0)
+    GtkStyleContext *style;
+
+    /* Set the default color */
+    style = gtk_widget_get_style_context (self->details->widget);
+    gtk_style_context_save (style);
+    gtk_style_context_set_state (style, GTK_STATE_FLAG_NORMAL);
+    if (self->details->use_base) {
+        gtk_style_context_add_class (style, GTK_STYLE_CLASS_VIEW);
+    }
+    gtk_style_context_get_background_color (style,
+                                            gtk_style_context_get_state (style),
+                                            &self->details->default_color);
+    gtk_style_context_restore (style);
+#else
+    GtkStyle *style;
 
     /* Set the default color */
     style = gtk_widget_get_style (self->details->widget);
@@ -344,6 +400,7 @@ eel_background_ensure_realized (EelBackground *self)
     } else {
         self->details->default_color = style->bg[GTK_STATE_NORMAL];
     }
+#endif
 
     /* If the window size is the same as last time, don't update */
     drawable_get_adjusted_size (self, &width, &height);
@@ -373,18 +430,10 @@ void
 eel_background_draw (GtkWidget *widget,
 #  if GTK_CHECK_VERSION (3, 0, 0)
                      cairo_t   *cr)
-#  else
-                     GdkEventExpose *event)
-#  endif
 {
     int width, height;
     GdkWindow *window = gtk_widget_get_window (widget);
-    GdkColor color;
-
-#  if !GTK_CHECK_VERSION (3, 0, 0)
-    if (event->window != window)
-        return;
-#  endif
+    GdkRGBA color;
 
     EelBackground *self = eel_get_widget_background (widget);
 
@@ -394,11 +443,39 @@ eel_background_draw (GtkWidget *widget,
     color = self->details->default_color;
     make_color_inactive (self, &color);
 
-#  if GTK_CHECK_VERSION(3,0,0)
     cairo_save (cr);
+
+    if (self->details->bg_surface != NULL) {
+        cairo_set_source_surface (cr, self->details->bg_surface, 0, 0);
+        cairo_pattern_set_extend (cairo_get_source (cr), CAIRO_EXTEND_REPEAT);
+    } else {
+        gdk_cairo_set_source_rgba (cr, &color);
+    }
+
+    cairo_rectangle (cr, 0, 0, width, height);
+    cairo_fill (cr);
+
+    cairo_restore (cr);
+}
 #  else
+                     GdkEventExpose *event)
+{
+    int width, height;
+    GdkWindow *window = gtk_widget_get_window (widget);
+    GdkColor color;
+
+    if (event->window != window)
+        return;
+
+    EelBackground *self = eel_get_widget_background (widget);
+
+    drawable_get_adjusted_size (self, &width, &height);
+
+    eel_background_ensure_realized (self);
+    color = self->details->default_color;
+    make_color_inactive (self, &color);
+
     cairo_t *cr = gdk_cairo_create (window);
-#  endif
 
     if (self->details->bg_surface != NULL) {
         cairo_set_source_surface (cr, self->details->bg_surface, 0, 0);
@@ -407,20 +484,15 @@ eel_background_draw (GtkWidget *widget,
         gdk_cairo_set_source_color (cr, &color);
     }
 
-#  if !GTK_CHECK_VERSION (3, 0, 0)
     gdk_cairo_rectangle (cr, &event->area);
     cairo_clip (cr);
-#  endif
 
     cairo_rectangle (cr, 0, 0, width, height);
     cairo_fill (cr);
 
-#  if GTK_CHECK_VERSION(3,0,0)
-    cairo_restore (cr);
-#  else
     cairo_destroy (cr);
-#  endif
 }
+#  endif
 
 static void
 set_root_surface (EelBackground *self,
@@ -533,7 +605,11 @@ eel_background_set_up_widget (EelBackground *self)
 {
     GdkWindow *window;
     GtkWidget *widget = self->details->widget;
+#  if GTK_CHECK_VERSION (3, 0, 0)
+    GdkRGBA color;
+#else
     GdkColor color;
+#endif
     gboolean in_fade = FALSE;
 
     if (!gtk_widget_get_realized (widget))
@@ -573,7 +649,11 @@ eel_background_set_up_widget (EelBackground *self)
         }
         else
         {
+#if GTK_CHECK_VERSION (3, 0, 0)
+            gdk_window_set_background_rgba (window, &color);
+#else
             gdk_window_set_background (window, &color);
+#endif
 #  if !GTK_CHECK_VERSION (3, 0, 0)
             gdk_window_set_back_pixmap (window, self->details->bg_surface, FALSE);
 #  endif
@@ -1071,10 +1151,21 @@ eel_background_set_dropped_color (EelBackground *self,
     top_border = 32;
     bottom_border = allocation.height - 32;
 
+#if GTK_CHECK_VERSION (3, 0, 0)
+    /* If a custom background color isn't set, get the GtkStyleContext's bg color. */
+#else
     /* If a custom background color isn't set, get the GtkStyle's bg color. */
+#endif
     if (!self->details->color)
     {
+#if GTK_CHECK_VERSION (3, 0, 0)
+        GtkStyleContext *style = gtk_widget_get_style_context (widget);
+        GdkRGBA bg;
+        gtk_style_context_get_background_color (style, GTK_STATE_FLAG_NORMAL, &bg);
+        gradient_spec = gdk_rgba_to_string (&bg);
+#else
         gradient_spec = gdk_color_to_string (&gtk_widget_get_style (widget)->bg[GTK_STATE_NORMAL]);
+#endif
     }
     else
     {

--- a/eel/eel-background.c
+++ b/eel/eel-background.c
@@ -475,7 +475,7 @@ eel_background_draw (GtkWidget *widget,
     color = self->details->default_color;
     make_color_inactive (self, &color);
 
-    cairo_t *cr = gdk_cairo_create (window);
+    cairo_t *cr = cairo_create (window);
 
     if (self->details->bg_surface != NULL) {
         cairo_set_source_surface (cr, self->details->bg_surface, 0, 0);

--- a/eel/eel-canvas-rect-ellipse.c
+++ b/eel/eel-canvas-rect-ellipse.c
@@ -833,7 +833,7 @@ eel_canvas_rect_draw (EelCanvasItem *item, GdkDrawable *drawable, GdkEventExpose
 #if GTK_CHECK_VERSION(3,0,0)
     cairo_save (cr);
 #else
-    cairo_t *cr = gdk_cairo_create (drawable);
+    cairo_t *cr = cairo_create (drawable);
     gdk_cairo_region (cr, expose->region);
     cairo_clip (cr);
 #endif
@@ -1160,7 +1160,7 @@ eel_canvas_ellipse_draw (EelCanvasItem *item, GdkDrawable *drawable, GdkEventExp
 #if GTK_CHECK_VERSION(3,0,0)
     cairo_save (cr);
 #else
-    cairo_t *cr = gdk_cairo_create (drawable);
+    cairo_t *cr = cairo_create (drawable);
     gdk_cairo_region (cr, expose->region);
     cairo_clip (cr);
 #endif

--- a/eel/eel-canvas.c
+++ b/eel/eel-canvas.c
@@ -3267,7 +3267,7 @@ static void
 eel_canvas_draw_background (EelCanvas *canvas,
                             int x, int y, int width, int height)
 {
-    cairo_t *cr = gdk_cairo_create (gtk_layout_get_bin_window (&canvas->layout));
+    cairo_t *cr = cairo_create (gtk_layout_get_bin_window (&canvas->layout));
 
     /* By default, we use the style background. */
     gdk_cairo_set_source_color (cr, &gtk_widget_get_style (GTK_WIDGET (canvas))->bg[GTK_STATE_NORMAL]);

--- a/eel/eel-editable-label.c
+++ b/eel/eel-editable-label.c
@@ -1673,7 +1673,7 @@ eel_editable_label_draw_cursor (EelEditableLabel  *label, gint xoffset, gint yof
         {
             cairo_region_t *clip;
 
-            cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+            cairo_t *cr = cairo_create (gtk_widget_get_window (widget));
 
             cairo_set_source_rgb (cr, 0, 0, 0);
             cairo_rectangle (cr,
@@ -1867,7 +1867,7 @@ eel_editable_label_expose (GtkWidget      *widget,
         					     range,
         					     1);
 
-            cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+            cairo_t *cr = cairo_create (gtk_widget_get_window (widget));
             gdk_cairo_region (cr, clip);
             cairo_clip (cr);
 
@@ -1894,7 +1894,7 @@ eel_editable_label_expose (GtkWidget      *widget,
             GtkAllocation allocation;
 
             gtk_widget_get_allocation (widget, &allocation);
-            cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+            cairo_t *cr = cairo_create (gtk_widget_get_window (widget));
             gdk_cairo_set_source_color (cr, &style->text [gtk_widget_get_state (widget)]);
             cairo_set_line_width (cr, 1.0);
             cairo_rectangle (cr, 0.5, 0.5, 

--- a/eel/eel-gdk-extensions.c
+++ b/eel/eel-gdk-extensions.c
@@ -594,7 +594,7 @@ eel_gdk_draw_layout_with_drop_shadow (GdkDrawable         *drawable,
                                       PangoLayout         *layout)
 {
     cairo_t *cr;
-    cr = gdk_cairo_create (drawable);
+    cr = cairo_create (drawable);
 
     gdk_cairo_set_source_color (cr, shadow_color);
     cairo_move_to (cr, x+1, y+1);

--- a/eel/eel-gdk-extensions.h
+++ b/eel/eel-gdk-extensions.h
@@ -102,16 +102,26 @@ char *              eel_gradient_set_bottom_color_spec     (const char          
 /* A version of parse_color that substitutes a default color instead of returning
    a boolean to indicate it cannot be parsed.
 */
+#if GTK_CHECK_VERSION (3, 0, 0)
+void                eel_gdk_rgba_parse_with_white_default  (GdkRGBA             *parsed_color,
+        const char          *color_spec);
+#else
 void                eel_gdk_color_parse_with_white_default (const char          *color_spec,
         GdkColor            *parsed_color);
+#endif
 guint32             eel_rgb16_to_rgb                       (gushort              r,
         gushort              g,
         gushort              b);
 guint32             eel_rgb8_to_rgb                        (guchar               r,
         guchar               g,
         guchar               b);
+#if GTK_CHECK_VERSION (3, 0, 0)
+guint32             eel_gdk_rgba_to_rgb                    (const GdkRGBA       *color);
+GdkRGBA             eel_gdk_rgb_to_rgba                    (guint32              color);
+#else
 guint32             eel_gdk_color_to_rgb                   (const GdkColor      *color);
 GdkColor            eel_gdk_rgb_to_color                   (guint32              color);
+#endif
 char *              eel_gdk_rgb_to_color_spec              (guint32              color);
 
 #if GTK_CHECK_VERSION(3,0,0)

--- a/eel/eel-gdk-pixbuf-extensions.c
+++ b/eel/eel-gdk-pixbuf-extensions.c
@@ -684,7 +684,7 @@ eel_gdk_pixbuf_draw_to_drawable (const GdkPixbuf *pixbuf,
     target.y1 = target.y0 + MIN (target_height, source_height);
 
 #if !GTK_CHECK_VERSION (3, 0, 0)
-	cr = gdk_cairo_create (drawable);
+	cr = cairo_create (drawable);
 #endif
 	gdk_cairo_set_source_pixbuf (cr, (GdkPixbuf *) pixbuf,
 				     source.x0 - target.x0, source.y0 - target.y0);

--- a/eel/eel-labeled-image.c
+++ b/eel/eel-labeled-image.c
@@ -375,10 +375,6 @@ static int
 #if GTK_CHECK_VERSION (3, 0, 0)
 eel_labeled_image_draw (GtkWidget *widget,
                         cairo_t *cr)
-#else
-eel_labeled_image_expose_event (GtkWidget *widget,
-                                GdkEventExpose *event)
-#endif
 {
     EelLabeledImage *labeled_image;
     EelIRect label_bounds;
@@ -387,9 +383,6 @@ eel_labeled_image_expose_event (GtkWidget *widget,
 
     g_assert (EEL_IS_LABELED_IMAGE (widget));
     g_assert (gtk_widget_get_realized (widget));
-#if !GTK_CHECK_VERSION (3, 0, 0)
-    g_assert (event != NULL);
-#endif
 
     labeled_image = EEL_LABELED_IMAGE (widget);
 
@@ -401,16 +394,9 @@ eel_labeled_image_expose_event (GtkWidget *widget,
         label_bounds = eel_labeled_image_get_label_bounds (EEL_LABELED_IMAGE (widget));
 
         gtk_paint_flat_box (style,
-#if GTK_CHECK_VERSION (3, 0, 0)
                             cr,
-#else
-                            window,
-#endif
                             gtk_widget_get_state (widget),
                             GTK_SHADOW_NONE,
-#if !GTK_CHECK_VERSION (3, 0, 0)
-                            &event->area,
-#endif
                             widget,
                             "eel-labeled-image",
                             label_bounds.x0, label_bounds.y0,
@@ -422,37 +408,22 @@ eel_labeled_image_expose_event (GtkWidget *widget,
     {
         eel_gtk_container_child_expose_event (GTK_CONTAINER (widget),
                                               labeled_image->details->label,
-#if GTK_CHECK_VERSION (3, 0, 0)
                                               cr);
-#else
-                                              event);
-#endif
     }
 
     if (labeled_image_show_image (labeled_image))
     {
         eel_gtk_container_child_expose_event (GTK_CONTAINER (widget),
                                               labeled_image->details->image,
-#if GTK_CHECK_VERSION (3, 0, 0)
                                               cr);
-#else
-                                              event);
-#endif
     }
 
     if (gtk_widget_has_focus (widget))
     {
         label_bounds = eel_labeled_image_get_image_bounds (EEL_LABELED_IMAGE (widget));
         gtk_paint_focus (style,
-#if GTK_CHECK_VERSION (3, 0, 0)
                          cr,
-#else
-                         window,
-#endif
                          GTK_STATE_NORMAL,
-#if !GTK_CHECK_VERSION (3, 0, 0)
-                         &event->area,
-#endif
                          widget,
                          "eel-focusable-labeled-image",
                          label_bounds.x0, label_bounds.y0,
@@ -462,6 +433,71 @@ eel_labeled_image_expose_event (GtkWidget *widget,
 
     return FALSE;
 }
+#else
+eel_labeled_image_expose_event (GtkWidget *widget,
+                                GdkEventExpose *event)
+{
+    EelLabeledImage *labeled_image;
+    EelIRect label_bounds;
+    GtkStyle *style;
+    GdkWindow *window;
+
+    g_assert (EEL_IS_LABELED_IMAGE (widget));
+    g_assert (gtk_widget_get_realized (widget));
+    g_assert (event != NULL);
+
+    labeled_image = EEL_LABELED_IMAGE (widget);
+
+    style = gtk_widget_get_style (widget);
+    window = gtk_widget_get_window (widget);
+    if (gtk_widget_get_state (widget) == GTK_STATE_SELECTED ||
+            gtk_widget_get_state (widget) == GTK_STATE_ACTIVE)
+    {
+        label_bounds = eel_labeled_image_get_label_bounds (EEL_LABELED_IMAGE (widget));
+
+        gtk_paint_flat_box (style,
+                            window,
+                            gtk_widget_get_state (widget),
+                            GTK_SHADOW_NONE,
+                            &event->area,
+                            widget,
+                            "eel-labeled-image",
+                            label_bounds.x0, label_bounds.y0,
+                            label_bounds.x1 - label_bounds.x0,
+                            label_bounds.y1 - label_bounds.y0);
+    }
+
+    if (labeled_image_show_label (labeled_image))
+    {
+        eel_gtk_container_child_expose_event (GTK_CONTAINER (widget),
+                                              labeled_image->details->label,
+                                              event);
+    }
+
+    if (labeled_image_show_image (labeled_image))
+    {
+        eel_gtk_container_child_expose_event (GTK_CONTAINER (widget),
+                                              labeled_image->details->image,
+                                              event);
+    }
+
+    if (gtk_widget_has_focus (widget))
+    {
+        label_bounds = eel_labeled_image_get_image_bounds (EEL_LABELED_IMAGE (widget));
+        gtk_paint_focus (style,
+                         window,
+                         GTK_STATE_NORMAL,
+                         &event->area,
+                         widget,
+                         "eel-focusable-labeled-image",
+                         label_bounds.x0, label_bounds.y0,
+                         label_bounds.x1 - label_bounds.x0,
+                         label_bounds.y1 - label_bounds.y0);
+    }
+
+    return FALSE;
+}
+#endif
 
 static void
 eel_labeled_image_map (GtkWidget *widget)

--- a/libcaja-private/caja-icon-canvas-item.c
+++ b/libcaja-private/caja-icon-canvas-item.c
@@ -640,7 +640,7 @@ caja_icon_canvas_item_get_image (CajaIconCanvasItem *item,
     }
 
     /* draw pixbuf to mask and pixmap */
-    cr = gdk_cairo_create (pixmap);
+    cr = cairo_create (pixmap);
     cairo_set_operator (cr, CAIRO_OPERATOR_SOURCE);
     gdk_cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
     cairo_paint (cr);
@@ -649,7 +649,7 @@ caja_icon_canvas_item_get_image (CajaIconCanvasItem *item,
     *mask = gdk_pixmap_new (gdk_screen_get_root_window (screen),
                             width, height,
                             1);
-    cr = gdk_cairo_create (*mask);
+    cr = cairo_create (*mask);
     cairo_set_operator (cr, CAIRO_OPERATOR_SOURCE);
     gdk_cairo_set_source_pixbuf (cr, pixbuf, 0, 0);
     cairo_paint (cr);
@@ -1049,7 +1049,7 @@ draw_frame (CajaIconCanvasItem *item,
             int width,
             int height)
 {
-    cairo_t *cr = gdk_cairo_create (drawable);
+    cairo_t *cr = cairo_create (drawable);
 
     /* Set the rounded rect clip region. Magic rounding value taken
      * from old code.
@@ -1817,7 +1817,7 @@ draw_stretch_handles (CajaIconCanvasItem *item,
 #if GTK_CHECK_VERSION(3,0,0)
     cairo_save (cr);
 #else
-    cairo_t *cr = gdk_cairo_create (drawable);
+    cairo_t *cr = cairo_create (drawable);
 #endif
     knob_pixbuf = get_knob_pixbuf ();
     knob_width = gdk_pixbuf_get_width (knob_pixbuf);
@@ -2030,7 +2030,7 @@ draw_pixbuf (GdkPixbuf *pixbuf,
 #else
 draw_pixbuf (GdkPixbuf *pixbuf, GdkDrawable *drawable, int x, int y)
 {
-    cairo_t *cr = gdk_cairo_create (drawable);
+    cairo_t *cr = cairo_create (drawable);
     gdk_cairo_set_source_pixbuf (cr, pixbuf, x, y);
     cairo_paint (cr);
     cairo_destroy (cr);
@@ -2296,7 +2296,7 @@ draw_embedded_text (CajaIconCanvasItem *item,
     gtk_style_context_restore (style_context);
     cairo_restore (cr);
 #else
-    cairo_t *cr = gdk_cairo_create (drawable);
+    cairo_t *cr = cairo_create (drawable);
 
     cairo_rectangle (cr,
                      x + item->details->embedded_text_rect.x,
@@ -2377,7 +2377,7 @@ caja_icon_canvas_item_draw (EelCanvasItem *item, GdkDrawable *drawable,
     pixbuf_rect.width = gdk_pixbuf_get_width (temp_pixbuf);
     pixbuf_rect.height = gdk_pixbuf_get_height (temp_pixbuf);
 
-    cairo_t *cr = gdk_cairo_create (drawable);
+    cairo_t *cr = cairo_create (drawable);
     gdk_cairo_rectangle (cr, &expose->area);
     cairo_clip (cr);
     gdk_cairo_set_source_pixbuf (cr, temp_pixbuf, pixbuf_rect.x, pixbuf_rect.y);
@@ -2556,7 +2556,7 @@ draw_label_layout (CajaIconCanvasItem *item,
     }
     else
     {
-        cairo_t *cr = gdk_cairo_create (drawable);
+        cairo_t *cr = cairo_create (drawable);
         gdk_cairo_set_source_color (cr, label_color);
         cairo_move_to (cr, x, y);
         pango_cairo_show_layout (cr, layout);

--- a/libcaja-private/caja-icon-dnd.c
+++ b/libcaja-private/caja-icon-dnd.c
@@ -1562,7 +1562,7 @@ drag_begin_callback (GtkWidget      *widget,
     if (!use_mask && pixmap != NULL)
     {
         /* If composite works, make the icons partially transparent */
-        cairo_t *cr = gdk_cairo_create (pixmap);
+        cairo_t *cr = cairo_create (pixmap);
         cairo_set_operator (cr, CAIRO_OPERATOR_DEST_OUT);
         cairo_set_source_rgba(cr, 1,0,0,0.35);
         cairo_paint (cr);
@@ -1654,7 +1654,7 @@ drag_highlight_expose (GtkWidget      *widget,
                       NULL, widget, "dnd",
                       x, y, width, height);
 
-    cairo_t *cr = gdk_cairo_create (window);
+    cairo_t *cr = cairo_create (window);
 #endif
 
     cairo_set_line_width (cr, 1.0);

--- a/src/file-manager/fm-properties-window.c
+++ b/src/file-manager/fm-properties-window.c
@@ -3046,7 +3046,7 @@ paint_used_legend (GtkWidget *widget,
 	window = FM_PROPERTIES_WINDOW (data);
 
 #if !GTK_CHECK_VERSION(3,0,0)
-	cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+	cairo_t *cr = cairo_create (gtk_widget_get_window (widget));
 #endif
 
 	cairo_rectangle  (cr,
@@ -3096,7 +3096,7 @@ paint_free_legend (GtkWidget *widget,
   	width  = allocation.width;
   	height = allocation.height;
 #if !GTK_CHECK_VERSION(3,0,0)
-  	cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+  	cairo_t *cr = cairo_create (gtk_widget_get_window (widget));
 #endif
 
 	cairo_rectangle (cr,
@@ -3161,7 +3161,7 @@ paint_pie_chart (GtkWidget *widget,
 	yc = height / 2;
 
 #if !GTK_CHECK_VERSION(3,0,0)
-  	cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+  	cairo_t *cr = cairo_create (gtk_widget_get_window (widget));
 #endif
 
 	if (width < height) {


### PR DESCRIPTION
This is deprecated in GTK 3.21 as of the troublesome commit
https://git.gnome.org/browse/gtk+/commit/?id=ad78daaf8081d8ea72006832ee3dd5df2e1ed3f9

Replace it with just cairo_create, no adverse effects observed in tests with compiz or
Marco, with or without compositing.