### PR TITLE
Remove libunique, use GtkApplication

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -455,9 +455,7 @@ check_required_directories (CajaApplication *application)
 
         dialog = eel_show_error_dialog (error_string, detail_string, NULL);
         /* We need the main event loop so the user has a chance to see the dialog. */
-#if GTK_CHECK_VERSION (3, 0, 0)
-        caja_main_event_loop_register (GTK_WIDGET (dialog));
-#else
+#if 	!GTK_CHECK_VERSION (3, 0, 0)
         caja_main_event_loop_register (GTK_OBJECT (dialog));
 #endif
 

--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -941,6 +941,7 @@ caja_application_startup (CajaApplication *application,
         if (!no_desktop)
         {
                 caja_application_open_desktop (application);
+                finish_startup (application, no_desktop);
         }
 
 #if GTK_CHECK_VERSION (3, 0, 0)

--- a/src/caja-application.h
+++ b/src/caja-application.h
@@ -29,7 +29,6 @@
 
 #include <gdk/gdk.h>
 #include <gio/gio.h>
-#include <unique/unique.h>
 #include <libegg/eggsmclient.h>
 
 #define CAJA_DESKTOP_ICON_VIEW_IID "OAFIID:Caja_File_Manager_Desktop_Icon_View"
@@ -62,7 +61,6 @@ typedef struct CajaShell CajaShell;
 typedef struct
 {
     GObject parent;
-    UniqueApp* unique_app;
     EggSMClient* smclient;
     GVolumeMonitor* volume_monitor;
     unsigned int automount_idle_id;

--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -620,10 +620,11 @@ main (int argc, char *argv[])
         {
             no_default_window = TRUE;
         }
+#if GTK_CHECK_VERSION(3, 0, 0)
         if (g_getenv ("CAJA_PERSIST") != NULL) {
 		    g_application_hold (G_APPLICATION (application));
         }
-
+#endif
 
         caja_application_startup
         (application,

--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -620,6 +620,10 @@ main (int argc, char *argv[])
         {
             no_default_window = TRUE;
         }
+        if (g_getenv ("CAJA_PERSIST") != NULL) {
+		    g_application_hold (G_APPLICATION (application));
+        }
+
 
         caja_application_startup
         (application,

--- a/src/caja-main.c
+++ b/src/caja-main.c
@@ -634,12 +634,13 @@ main (int argc, char *argv[])
          uris);
         g_strfreev (uris);
 
+#if !GTK_CHECK_VERSION(3, 0, 0)
         if (unique_app_is_running (application->unique_app) ||
                 kill_shell)
         {
             exit_with_last_window = TRUE;
         }
-
+#endif
         if (is_event_loop_needed ())
         {
             gtk_main ();

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -218,7 +218,11 @@ caja_window_init (CajaWindow *window)
                              G_CALLBACK (caja_window_load_extension_menus), window, G_CONNECT_SWAPPED);
 
 /* Keep the main event loop alive as long as the window exists */
-#if !GTK_CHECK_VERSION(3, 0, 0)
+#if GTK_CHECK_VERSION(3, 0, 0)
+    /* FIXME: port to GtkApplication with GTK3 */
+    //gtk_quit_add_destroy (1, GTK_WIDGET (window));
+    caja_main_event_loop_register (GTK_WIDGET (window));
+#else
     gtk_quit_add_destroy (1, GTK_OBJECT (window));
     caja_main_event_loop_register (GTK_OBJECT (window));
 #endif

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -101,7 +101,7 @@ static void action_view_as_callback         (GtkAction               *action,
 
 static GList *history_list;
 
-G_DEFINE_TYPE_WITH_CODE (CajaWindow, caja_window, GTK_TYPE_WINDOW,
+G_DEFINE_TYPE_WITH_CODE (CajaWindow, caja_window, GTK_TYPE_APPLICATION_WINDOW,
                          G_IMPLEMENT_INTERFACE (CAJA_TYPE_WINDOW_INFO,
                                  caja_window_info_iface_init));
 
@@ -215,11 +215,7 @@ caja_window_init (CajaWindow *window)
                              G_CALLBACK (caja_window_load_extension_menus), window, G_CONNECT_SWAPPED);
 
 /* Keep the main event loop alive as long as the window exists */
-#if GTK_CHECK_VERSION(3, 0, 0)
-    /* FIXME: port to GtkApplication with GTK3 */
-    //gtk_quit_add_destroy (1, GTK_WIDGET (window));
-    caja_main_event_loop_register (GTK_WIDGET (window));
-#else
+#if !GTK_CHECK_VERSION(3, 0, 0)
     gtk_quit_add_destroy (1, GTK_OBJECT (window));
     caja_main_event_loop_register (GTK_OBJECT (window));
 #endif

--- a/src/caja-window.c
+++ b/src/caja-window.c
@@ -101,7 +101,11 @@ static void action_view_as_callback         (GtkAction               *action,
 
 static GList *history_list;
 
+#if GTK_CHECK_VERSION(3, 0, 0)
 G_DEFINE_TYPE_WITH_CODE (CajaWindow, caja_window, GTK_TYPE_APPLICATION_WINDOW,
+#else
+G_DEFINE_TYPE_WITH_CODE (CajaWindow, caja_window, GTK_TYPE_WINDOW,
+#endif
                          G_IMPLEMENT_INTERFACE (CAJA_TYPE_WINDOW_INFO,
                                  caja_window_info_iface_init));
 

--- a/src/caja-window.h
+++ b/src/caja-window.h
@@ -83,8 +83,11 @@ typedef struct CajaWindowDetails CajaWindowDetails;
 
 typedef struct
 {
+#if GTK_CHECK_VERSION(3, 0, 0)
     GtkApplicationWindowClass  parent_spot;
-
+#else
+    GtkWindowClass   parent_spot;
+#endif
     CajaWindowType window_type;
     const char *bookmarks_placeholder;
 
@@ -118,8 +121,11 @@ typedef struct
 
 struct CajaWindow
 {
+#if GTK_CHECK_VERSION(3, 0, 0)
     GtkApplicationWindow parent_object;
-
+#else
+    GtkWindow parent_object;
+#endif
     CajaWindowDetails *details;
 
     CajaApplication *application;

--- a/src/caja-window.h
+++ b/src/caja-window.h
@@ -83,7 +83,7 @@ typedef struct CajaWindowDetails CajaWindowDetails;
 
 typedef struct
 {
-    GtkWindowClass parent_spot;
+    GtkApplicationWindowClass  parent_spot;
 
     CajaWindowType window_type;
     const char *bookmarks_placeholder;
@@ -118,7 +118,7 @@ typedef struct
 
 struct CajaWindow
 {
-    GtkWindow parent_object;
+    GtkApplicationWindow parent_object;
 
     CajaWindowDetails *details;
 


### PR DESCRIPTION
Remove dependency on libunique, use GtkApplication instead. Since finish_startup has been restored to duty, Caja now performs properly in testing on my system. Only changed behavior is that if Caja is started from terminal with no arguments a second instance results, just as if a root instance has been started. Starting with arguments like a directory to open brings up a new window in the existing instance,

This is GTK3 only due to build failures if the GTK3 selectors were put in the includes in caja-application.h . Configure.ac is unchanged so far due again to problems in removing libunique checks for GTK3 while keeping it for GTK2. Will build and run with libunique removed entirely from configure.ac however.

If we decide to support GTK2 in 1.16 I can probably add it back but might be a lot of extra work.
