### PR TITLE
Fix desktop redraw, do not change other GTK version builds

### DIFF
--- a/data/caja.css
+++ b/data/caja.css
@@ -3,6 +3,15 @@
     border-radius: 3px;
 }
 
+.caja-desktop-window,
+.caja-desktop:not(:selected):not(:active):not(.rubberband){
+	background-color: transparent;
+}
+/*color of desktop when compositor is not available*/
+.caja-fallback-desktop-background{
+	background-color: #114466;
+}
+
 /* desktop mode */
 .caja-desktop.caja-canvas-item {
     color: #ffffff;

--- a/libcaja-private/caja-icon-container.c
+++ b/libcaja-private/caja-icon-container.c
@@ -4666,7 +4666,8 @@ realize (GtkWidget *widget)
     GTK_WIDGET_CLASS (caja_icon_container_parent_class)->realize (widget);
 
     container = CAJA_ICON_CONTAINER (widget);
-
+     /* Unless GTK 3.21 or later is in use and the desktop must be transparent*/
+#if !GTK_CHECK_VERSION(3, 21, 0)
     /* Ensure that the desktop window is native so the background
        set on it is drawn by X. */
     if (container->details->is_desktop)
@@ -4677,7 +4678,7 @@ realize (GtkWidget *widget)
         gdk_x11_drawable_get_xid (gtk_layout_get_bin_window (GTK_LAYOUT (widget)));
 #endif
     }
-
+#endif
     /* Set up DnD.  */
     caja_icon_dnd_init (container);
 
@@ -6243,6 +6244,7 @@ popup_menu (GtkWidget *widget)
     return TRUE;
 }
 
+#if !GTK_CHECK_VERSION(3, 21, 0)
 static void
 draw_canvas_background (EelCanvas *canvas,
 #if GTK_CHECK_VERSION(3,0,0)
@@ -6253,6 +6255,7 @@ draw_canvas_background (EelCanvas *canvas,
 {
     /* Don't chain up to the parent to avoid clearing and redrawing */
 }
+#endif
 
 
 #if !GTK_CHECK_VERSION(3,0,0)
@@ -6737,8 +6740,9 @@ caja_icon_container_class_init (CajaIconContainerClass *class)
     widget_class->grab_notify = grab_notify_cb;
 
     canvas_class = EEL_CANVAS_CLASS (class);
+#if !GTK_CHECK_VERSION(3, 21, 0)
     canvas_class->draw_background = draw_canvas_background;
-
+#endif
     class->start_interactive_search = caja_icon_container_start_interactive_search;
 
 #if GTK_CHECK_VERSION(3,0,0)

--- a/src/caja-desktop-window.c
+++ b/src/caja-desktop-window.c
@@ -167,6 +167,13 @@ map (GtkWidget *widget)
     /* Chain up to realize our children */
     GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->map (widget);
     gdk_window_lower (gtk_widget_get_window (widget));
+#if GTK_CHECK_VERSION(3, 21, 0)
+    GdkWindow *window;
+    GdkRGBA transparent = { 0, 0, 0, 0 };
+
+    window = gtk_widget_get_window (widget);
+    gdk_window_set_background_rgba (window, &transparent);
+#endif
 }
 
 static void
@@ -236,14 +243,21 @@ realize (GtkWidget *widget)
 {
     CajaDesktopWindow *window;
 	CajaDesktopWindowDetails *details;
-
+#if GTK_CHECK_VERSION(3, 21, 0)
+        GdkVisual *visual;
+#endif
     window = CAJA_DESKTOP_WINDOW (widget);
 	details = window->details;
 
     /* Make sure we get keyboard events */
     gtk_widget_set_events (widget, gtk_widget_get_events (widget)
                            | GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK);
-
+#if GTK_CHECK_VERSION(3, 21, 0)
+    visual = gdk_screen_get_rgba_visual (gtk_widget_get_screen (widget));
+    if (visual) {
+        gtk_widget_set_visual (widget, visual);
+    }
+#endif
     /* Do the work of realizing. */
     GTK_WIDGET_CLASS (caja_desktop_window_parent_class)->realize (widget);
 

--- a/src/file-manager/fm-desktop-icon-view.c
+++ b/src/file-manager/fm-desktop-icon-view.c
@@ -38,6 +38,9 @@
 #include <gdk/gdkx.h>
 #include <glib/gi18n.h>
 #include <libcaja-private/caja-desktop-icon-file.h>
+#if !GTK_CHECK_VERSION(3, 21, 0)
+#include <libcaja-private/caja-directory-background.h>
+#endif
 #include <libcaja-private/caja-directory-background.h>
 #include <libcaja-private/caja-directory-notify.h>
 #include <libcaja-private/caja-file-changes-queue.h>
@@ -473,6 +476,17 @@ realized_callback (GtkWidget *widget, FMDesktopIconView *desktop_icon_view)
     gdk_window_add_filter (root_window,
                            desktop_icon_view_property_filter,
                            desktop_icon_view);
+
+    /*Set up a fallback background style class for the noncompositing case */
+#if GTK_CHECK_VERSION(3, 21, 0)
+    gboolean
+    composited = gtk_widget_is_composited (GTK_WIDGET(desktop_icon_view));
+        if (!composited){
+            GtkStyleContext *context;
+            context = gtk_widget_get_style_context (GTK_WIDGET(desktop_icon_view));
+            gtk_style_context_add_class(context,"caja-fallback-desktop-background");
+        }
+#endif
 }
 
 static CajaZoomLevel

--- a/src/file-manager/fm-directory-view.c
+++ b/src/file-manager/fm-directory-view.c
@@ -61,7 +61,9 @@
 #include <libcaja-private/caja-desktop-directory.h>
 #include <libcaja-private/caja-extensions.h>
 #include <libcaja-private/caja-search-directory.h>
+#if !GTK_CHECK_VERSION(3, 21, 0)
 #include <libcaja-private/caja-directory-background.h>
+#endif
 #include <libcaja-private/caja-directory.h>
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-file-attributes.h>
@@ -421,7 +423,9 @@ EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, can_zoom_in)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, can_zoom_out)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, clear)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, file_changed)
+#if !GTK_CHECK_VERSION(3, 21, 0)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_background_widget)
+#endif
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_selection)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_selection_for_file_transfer)
 EEL_IMPLEMENT_MUST_OVERRIDE_SIGNAL (fm_directory_view, get_item_count)
@@ -3688,6 +3692,7 @@ fm_directory_view_can_zoom_out (FMDirectoryView *view)
 		 can_zoom_out, (view));
 }
 
+#if !GTK_CHECK_VERSION(3, 21, 0)
 GtkWidget *
 fm_directory_view_get_background_widget (FMDirectoryView *view)
 {
@@ -3713,7 +3718,7 @@ real_set_is_active (FMDirectoryView *view,
 	bg = fm_directory_view_get_background (view);
 	eel_background_set_active (bg, is_active);
 }
-
+#endif
 static void
 fm_directory_view_set_is_active (FMDirectoryView *view,
 				 gboolean is_active)
@@ -7749,10 +7754,11 @@ real_merge_menus (FMDirectoryView *view)
 
 	ui = caja_ui_string_get ("caja-directory-view-ui.xml");
 	view->details->dir_merge_id = gtk_ui_manager_add_ui_from_string (ui_manager, ui, -1, NULL);
+#if !GTK_CHECK_VERSION(3, 21, 0)
 	g_signal_connect_object (fm_directory_view_get_background (view), "settings_changed",
 				 G_CALLBACK (schedule_update_menus), G_OBJECT (view),
 				 G_CONNECT_SWAPPED);
-
+#endif
 	view->details->scripts_invalid = TRUE;
 	view->details->templates_invalid = TRUE;
 }
@@ -11111,8 +11117,9 @@ fm_directory_view_class_init (FMDirectoryViewClass *klass)
         klass->merge_menus = real_merge_menus;
         klass->unmerge_menus = real_unmerge_menus;
         klass->update_menus = real_update_menus;
-	klass->set_is_active = real_set_is_active;
-
+#if !GTK_CHECK_VERSION(3, 21, 0)
+        klass->set_is_active = real_set_is_active;
+#endif
 	/* Function pointers that subclasses must override */
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, add_file);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, bump_zoom_level);
@@ -11120,7 +11127,9 @@ fm_directory_view_class_init (FMDirectoryViewClass *klass)
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, can_zoom_out);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, clear);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, file_changed);
-	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_background_widget);
+#if !GTK_CHECK_VERSION(3, 21, 0)
+       EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_background_widget);
+#endif
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_selection);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_selection_for_file_transfer);
 	EEL_ASSIGN_MUST_OVERRIDE_SIGNAL (klass, fm_directory_view, get_item_count);

--- a/src/file-manager/fm-icon-view.c
+++ b/src/file-manager/fm-icon-view.c
@@ -30,7 +30,9 @@
 #include "fm-desktop-icon-view.h"
 #include "fm-error-reporting.h"
 #include <stdlib.h>
+#if !GTK_CHECK_VERSION(3, 21, 0)
 #include <eel/eel-background.h>
+#endif
 #include <eel/eel-glib-extensions.h>
 #include <eel/eel-gtk-extensions.h>
 #include <eel/eel-gtk-macros.h>
@@ -43,7 +45,9 @@
 #include <glib/gi18n.h>
 #include <gio/gio.h>
 #include <libcaja-private/caja-clipboard-monitor.h>
+#if !GTK_CHECK_VERSION(3, 21, 0)
 #include <libcaja-private/caja-directory-background.h>
+#endif
 #include <libcaja-private/caja-directory.h>
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-file-utilities.h>
@@ -1277,7 +1281,7 @@ fm_icon_view_begin_loading (FMDirectoryView *view)
 
     /* kill any sound preview process that is ongoing */
     preview_audio (icon_view, NULL, FALSE);
-
+#if !GTK_CHECK_VERSION(3, 21, 0)
     /* FIXME bugzilla.gnome.org 45060: Should use methods instead
      * of hardcoding desktop knowledge in here.
      */
@@ -1301,7 +1305,7 @@ fm_icon_view_begin_loading (FMDirectoryView *view)
         caja_connect_background_to_file_metadata (icon_container, file, default_action);
     }
 
-
+#endif
     /* Set up the zoom level from the metadata. */
     if (fm_directory_view_supports_zooming (FM_DIRECTORY_VIEW (icon_view)))
     {
@@ -1507,6 +1511,7 @@ fm_icon_view_can_zoom_out (FMDirectoryView *view)
            > CAJA_ZOOM_LEVEL_SMALLEST;
 }
 
+#if !GTK_CHECK_VERSION(3, 21, 0)
 static GtkWidget *
 fm_icon_view_get_background_widget (FMDirectoryView *view)
 {
@@ -1514,6 +1519,7 @@ fm_icon_view_get_background_widget (FMDirectoryView *view)
 
     return GTK_WIDGET (get_icon_container (FM_ICON_VIEW (view)));
 }
+#endif
 
 static gboolean
 fm_icon_view_is_empty (FMDirectoryView *view)
@@ -3168,7 +3174,9 @@ fm_icon_view_class_init (FMIconViewClass *klass)
     fm_directory_view_class->clear = fm_icon_view_clear;
     fm_directory_view_class->end_loading = fm_icon_view_end_loading;
     fm_directory_view_class->file_changed = fm_icon_view_file_changed;
+#if !GTK_CHECK_VERSION(3, 21, 0)
     fm_directory_view_class->get_background_widget = fm_icon_view_get_background_widget;
+#endif
     fm_directory_view_class->get_selected_icon_locations = fm_icon_view_get_selected_icon_locations;
     fm_directory_view_class->get_selection = fm_icon_view_get_selection;
     fm_directory_view_class->get_selection_for_file_transfer = fm_icon_view_get_selection;

--- a/src/file-manager/fm-list-view.c
+++ b/src/file-manager/fm-list-view.c
@@ -47,7 +47,9 @@
 #include <libcaja-private/caja-column-chooser.h>
 #include <libcaja-private/caja-column-utilities.h>
 #include <libcaja-private/caja-debug-log.h>
+#if !GTK_CHECK_VERSION(3, 21, 0)
 #include <libcaja-private/caja-directory-background.h>
+#endif
 #include <libcaja-private/caja-dnd.h>
 #include <libcaja-private/caja-file-dnd.h>
 #include <libcaja-private/caja-file-utilities.h>
@@ -2125,11 +2127,13 @@ fm_list_view_file_changed (FMDirectoryView *view, CajaFile *file, CajaDirectory 
     }
 }
 
+#if !GTK_CHECK_VERSION(3, 21, 0)
 static GtkWidget *
 fm_list_view_get_background_widget (FMDirectoryView *view)
 {
     return GTK_WIDGET (view);
 }
+#endif
 
 static void
 fm_list_view_get_selection_foreach_func (GtkTreeModel *model, GtkTreePath *path, GtkTreeIter *iter, gpointer data)
@@ -3331,7 +3335,9 @@ fm_list_view_class_init (FMListViewClass *class)
     fm_directory_view_class->click_policy_changed = fm_list_view_click_policy_changed;
     fm_directory_view_class->clear = fm_list_view_clear;
     fm_directory_view_class->file_changed = fm_list_view_file_changed;
+#if !GTK_CHECK_VERSION(3, 21, 0)
     fm_directory_view_class->get_background_widget = fm_list_view_get_background_widget;
+#endif
     fm_directory_view_class->get_selection = fm_list_view_get_selection;
     fm_directory_view_class->get_selection_for_file_transfer = fm_list_view_get_selection_for_file_transfer;
     fm_directory_view_class->get_item_count = fm_list_view_get_item_count;


### PR DESCRIPTION
This should be a 3-way version: No changes here that should affect GTK 2 builds, nor that would affect GTK 3.20 and earlier GTK3 builds. Fix the desktop in GTK 3.21 and later but do not disturb other builds. No impact on distros until they actually use GTK 3.22.

Apply the Nautilus/Nemo based changes for a transparent desktop that works in GTK 3.21 and later only when actually building against GTK 3.21. Tested in GTK 3.21.4 and in GTK 3.20.3 and worked both ways, desktop backgrounds rendered fine. In GTK 3.21 a fallback color is used if Caja is started without a compositor available, normally the desktop is transparent and mate-settings-daemon draws the background with GTK 3.21. In GTK 3.20 or older Caja draws the background as before.

Note that two files are not needed in GTK 3.21 builds but still build their output objects: caja-directory-background.c and caja-directory-background.h , I was unable to create a conditional makefile.am to exclude them. They caused no harm in GTK 3.21 but are dead code could be excluded with some makefile work. Also note that the change to caja.css is unconditional but the added selectors seemed to be ignored without problems in GTK 3.20 test builds.
