### PR TITLE
Fix GTK 2 build

### DIFF
--- a/src/caja-application.h
+++ b/src/caja-application.h
@@ -81,9 +81,10 @@ typedef struct
     GList *volume_queue;
 } CajaApplication;
 
-typedef struct
+
 #if GTK_CHECK_VERSION (3, 0, 0)
 {
+typedef struct
 	GtkApplicationClass parent_class;
 } CajaApplicationClass;
 
@@ -91,9 +92,10 @@ GType caja_application_get_type (void);
 
 CajaApplication *caja_application_dup_singleton (void);
 #else
+typedef struct
+{
     GObjectClass parent_class;
 } CajaApplicationClass;
-
 
 GType                caja_application_get_type          (void);
 CajaApplication *caja_application_new               (void);


### PR DESCRIPTION
As expected found an error blocking a GTK2 build-but only in this file. Fix it and GTK2 build now completes. Can't test it in my GTK3 MATE environment (get GTK2 and GTK3 symbol mix) but was able to build over a temporary installation of mate-desktop built with GTK2 in /usr/local.
