### PR TITLE
GTK3-fix distcheck fail

### DIFF
--- a/src/caja-application.c
+++ b/src/caja-application.c
@@ -2758,6 +2758,10 @@ if (help) {
             g_strfreev (remaining);
         }
 
+        /* initialize CSS theming */
+        init_css ();
+
+
         /* Create the other windows. */
         if (uris != NULL || !no_default_window) {
             open_windows (self, NULL,
@@ -2788,8 +2792,6 @@ caja_application_startup (GApplication *app)
     /* initialize the session manager client 
     caja_application_smclient_startup (self); */
 
-    /* initialize CSS theming */
-    init_css ();
 
     /* Initialize preferences. This is needed to create the
      * global GSettings objects.


### PR DESCRIPTION
Move init_css back to caja_application_startup as otherwise distcheck fails to load the css file. Loads in normal run either way. Got a sucessful distcheck run this way over GTK 3.21.4 , though the branch combining this with the desktop redraw fix is needed to actually run on GTK 3.21
